### PR TITLE
Hooks should inherit from IDisposable

### DIFF
--- a/Moonbow.Experimental/Hooks/ConnectionComponentHook.cs
+++ b/Moonbow.Experimental/Hooks/ConnectionComponentHook.cs
@@ -48,8 +48,24 @@ namespace AetharNet.Moonbow.Experimental.Hooks
 
         public override void Dispose()
         {
-            ClientConnectionHooks.Clear();
-            ServerConnectionHooks.Clear();
+            if (GameUtilities.IsClient)
+            {
+                foreach (var connectionHook in ClientConnectionHooks)
+                {
+                    connectionHook.Dispose();
+                }
+                
+                ClientConnectionHooks.Clear();
+            }
+            else if (GameUtilities.IsServer)
+            {
+                foreach (var connectionHook in ServerConnectionHooks)
+                {
+                    connectionHook.Dispose();
+                }
+                
+                ServerConnectionHooks.Clear();
+            }
         }
 
         public override void CleanupOldSession()

--- a/Moonbow.Experimental/Hooks/CoroutineHook.cs
+++ b/Moonbow.Experimental/Hooks/CoroutineHook.cs
@@ -52,5 +52,15 @@ namespace AetharNet.Moonbow.Experimental.Hooks
                 } while (shouldLoop);
             }
         }
+
+        public override void Dispose()
+        {
+            foreach (var coroutine in Coroutines)
+            {
+                coroutine.Dispose();
+            }
+            
+            Coroutines.Clear();
+        }
     }
 }

--- a/Moonbow.Experimental/Hooks/MessagingComponentHook.cs
+++ b/Moonbow.Experimental/Hooks/MessagingComponentHook.cs
@@ -39,8 +39,24 @@ namespace AetharNet.Moonbow.Experimental.Hooks
 
         public override void Dispose()
         {
-            ClientMessagingHooks.Clear();
-            ServerMessagingHooks.Clear();
+            if (GameUtilities.IsClient)
+            {
+                foreach (var messagingHook in ClientMessagingHooks)
+                {
+                    messagingHook.Dispose();
+                }
+                
+                ClientMessagingHooks.Clear();
+            }
+            else if (GameUtilities.IsServer)
+            {
+                foreach (var messagingHook in ServerMessagingHooks)
+                {
+                    messagingHook.Dispose();
+                }
+                
+                ServerMessagingHooks.Clear();
+            }
         }
     }
 }

--- a/Moonbow.Experimental/Hooks/MessagingComponentHook.cs
+++ b/Moonbow.Experimental/Hooks/MessagingComponentHook.cs
@@ -3,9 +3,7 @@ using AetharNet.Moonbow.Experimental.Patches;
 using AetharNet.Moonbow.Experimental.Templates;
 using AetharNet.Moonbow.Experimental.Utilities;
 using Plukit.Base;
-using Staxel;
 using Staxel.Modding;
-using Staxel.Translation;
 
 namespace AetharNet.Moonbow.Experimental.Hooks
 {

--- a/Moonbow.Experimental/Hooks/ModRequirementHook.cs
+++ b/Moonbow.Experimental/Hooks/ModRequirementHook.cs
@@ -60,5 +60,10 @@ namespace AetharNet.Moonbow.Experimental.Hooks
                     Callbacks.Remove(requestCode);
                 });
         }
+
+        public override void Dispose()
+        {
+            Callbacks.Clear();
+        }
     }
 }

--- a/Moonbow.Experimental/Hooks/ModRequirementHook.cs
+++ b/Moonbow.Experimental/Hooks/ModRequirementHook.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using AetharNet.Moonbow.Experimental.Interfaces;
 using AetharNet.Moonbow.Experimental.Templates;
 using AetharNet.Moonbow.Experimental.Utilities;
-using Plukit.Base;
 using Staxel.Commands;
 using Staxel.Core;
 using Staxel.Logic;

--- a/Moonbow.Experimental/Interfaces/IClientConnectionHook.cs
+++ b/Moonbow.Experimental/Interfaces/IClientConnectionHook.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Staxel.Logic;
-using Staxel.Modding;
 
 namespace AetharNet.Moonbow.Experimental.Interfaces
 {

--- a/Moonbow.Experimental/Interfaces/IClientConnectionHook.cs
+++ b/Moonbow.Experimental/Interfaces/IClientConnectionHook.cs
@@ -1,4 +1,5 @@
-﻿using Staxel.Logic;
+﻿using System;
+using Staxel.Logic;
 using Staxel.Modding;
 
 namespace AetharNet.Moonbow.Experimental.Interfaces
@@ -8,7 +9,7 @@ namespace AetharNet.Moonbow.Experimental.Interfaces
     /// Act upon events on the client.
     /// NOTE: Events are not immediate, as the current implementation relies on the client-side player list, which retrieves updates every so often.
     /// </summary>
-    public interface IClientConnectionHook
+    public interface IClientConnectionHook : IDisposable
     {
         /// <summary>
         /// Event fired whenever a player joins the game.

--- a/Moonbow.Experimental/Interfaces/IClientMessagingHook.cs
+++ b/Moonbow.Experimental/Interfaces/IClientMessagingHook.cs
@@ -1,4 +1,5 @@
-﻿using Staxel.Modding;
+﻿using System;
+using Staxel.Modding;
 
 namespace AetharNet.Moonbow.Experimental.Interfaces
 {
@@ -6,7 +7,7 @@ namespace AetharNet.Moonbow.Experimental.Interfaces
     /// Mod hook with extended messaging functionality.
     /// Intercept/modify/act upon message events on the client.
     /// </summary>
-    public interface IClientMessagingHook
+    public interface IClientMessagingHook : IDisposable
     {
         /// <summary>
         /// Intercept or modify a command being sent by the client.

--- a/Moonbow.Experimental/Interfaces/IClientMessagingHook.cs
+++ b/Moonbow.Experimental/Interfaces/IClientMessagingHook.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Staxel.Modding;
 
 namespace AetharNet.Moonbow.Experimental.Interfaces
 {

--- a/Moonbow.Experimental/Interfaces/IServerConnectionHook.cs
+++ b/Moonbow.Experimental/Interfaces/IServerConnectionHook.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Staxel.Logic;
-using Staxel.Modding;
 
 namespace AetharNet.Moonbow.Experimental.Interfaces
 {

--- a/Moonbow.Experimental/Interfaces/IServerConnectionHook.cs
+++ b/Moonbow.Experimental/Interfaces/IServerConnectionHook.cs
@@ -1,4 +1,5 @@
-﻿using Staxel.Logic;
+﻿using System;
+using Staxel.Logic;
 using Staxel.Modding;
 
 namespace AetharNet.Moonbow.Experimental.Interfaces
@@ -7,7 +8,7 @@ namespace AetharNet.Moonbow.Experimental.Interfaces
     /// Mod hook with extended player connection functionality.
     /// Act upon events on the server.
     /// </summary>
-    public interface IServerConnectionHook
+    public interface IServerConnectionHook : IDisposable
     {
         /// <summary>
         /// Event fired whenever a player joins the game.

--- a/Moonbow.Experimental/Interfaces/IServerMessagingHook.cs
+++ b/Moonbow.Experimental/Interfaces/IServerMessagingHook.cs
@@ -1,4 +1,5 @@
-﻿using Staxel.Commands;
+﻿using System;
+using Staxel.Commands;
 using Staxel.Logic;
 using Staxel.Modding;
 
@@ -8,7 +9,7 @@ namespace AetharNet.Moonbow.Experimental.Interfaces
     /// Mod hook with extended messaging functionality.
     /// Intercept/modify/act upon message events on the server.
     /// </summary>
-    public interface IServerMessagingHook
+    public interface IServerMessagingHook : IDisposable
     {
         /// <summary>
         /// Intercept or modify a command being received from a client.

--- a/Moonbow.Experimental/Interfaces/IServerMessagingHook.cs
+++ b/Moonbow.Experimental/Interfaces/IServerMessagingHook.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Staxel.Commands;
 using Staxel.Logic;
-using Staxel.Modding;
 
 namespace AetharNet.Moonbow.Experimental.Interfaces
 {

--- a/Moonbow.Experimental/Templates/ClientConnectionHookTemplate.cs
+++ b/Moonbow.Experimental/Templates/ClientConnectionHookTemplate.cs
@@ -4,6 +4,7 @@ namespace AetharNet.Moonbow.Experimental.Templates
 {
     public class ClientConnectionHookTemplate
     {
+        public virtual void Dispose() {}
         public virtual void OnPlayerConnect(Entity playerEntity) {}
         public virtual void OnPlayerDisconnect(Entity playerEntity) {}
         public virtual void OnPlayerRename(Entity playerEntity, string oldNickname) {}

--- a/Moonbow.Experimental/Templates/ClientMessagingHookTemplate.cs
+++ b/Moonbow.Experimental/Templates/ClientMessagingHookTemplate.cs
@@ -2,6 +2,7 @@
 {
     public class ClientMessagingHookTemplate
     {
+        public virtual void Dispose() {}
         public virtual bool InterceptOutgoingCommand(ref string command) => true;
         public virtual bool InterceptOutgoingMessage(ref string message) => true;
         public virtual bool InterceptIncomingMessage(string nick, ref string message) => true;

--- a/Moonbow.Experimental/Templates/ServerConnectionHookTemplate.cs
+++ b/Moonbow.Experimental/Templates/ServerConnectionHookTemplate.cs
@@ -4,6 +4,7 @@ namespace AetharNet.Moonbow.Experimental.Templates
 {
     public class ServerConnectionHookTemplate
     {
+        public virtual void Dispose() {}
         public virtual void OnPlayerConnect(Entity playerEntity) {}
         public virtual void OnPlayerDisconnect(Entity playerEntity) {}
         public virtual void OnPlayerKicked(Entity playerEntity) {}

--- a/Moonbow.Experimental/Templates/ServerMessagingHookTemplate.cs
+++ b/Moonbow.Experimental/Templates/ServerMessagingHookTemplate.cs
@@ -5,6 +5,7 @@ namespace AetharNet.Moonbow.Experimental.Templates
 {
     public class ServerMessagingHookTemplate
     {
+        public virtual void Dispose() {}
         public virtual bool InterceptPlayerCommand(EntityId entityId, ref string command, ICommandsApi api) => true;
         public virtual bool InterceptPlayerMessage(EntityId entityId, ref string message, ICommandsApi api) => true;
 


### PR DESCRIPTION
Inheriting from `IDisposable` allows mod creators to easily clean-up resources when no longer needed.